### PR TITLE
Restore sample clipping

### DIFF
--- a/src/assembly.h
+++ b/src/assembly.h
@@ -341,35 +341,6 @@ static __inline Word64 MADD64(Word64 sum64, int x, int y)
         return u.w64;
 }
 
-/* Ken's trick: clips to [-32768, 32767] */
-//sign = x >> 31;
-//if (sign != (x >> 15))
-//    x = sign ^ ((1 << 15) - 1);
-__attribute__((__always_inline__)) static __inline short SAR64_Clip(Word64 x, int n)
-{
-  unsigned int xLo = (unsigned int) x;
-  int xHi = (int) (x >> 32);
-  int nComp = 32-n;
-  int tmp;
-  // Shortcut: n is always < 32.
-  __asm__ __volatile__( "lsl %2, %0, %3\n\t"  // tmp <- xHi<<(32-n)
-                        "lsr %1, %1, %4\n\t"  // xLo <- xLo>>n
-                        "orr %1, %2\n\t"      // xLo <= xLo || tmp
-// Uncomment this part if you really need it to saturate the output to 16-bits
-// This didn't appear necessary because the temp data is shifted right by 26 bits
-// and doesn't grow large enough to overflow a 16-bit signed value
-//                        "asr %2, %1, #31\n\t" // get sign in tmp
-//                        "asr %0, %1, #15\n\t" // use xHi as tmp2
-//                        "mov %3, #-1\n\t" // prep constant 0x7fff
-//                        "lsr %3, #17\n\t"
-//                        "cmp %2, %0\n\t"      // if (sign != (x >> 15))
-//                        "it ne\n\t"
-//                        "eorne %1, %3\n\t"
-                        : "+&r" (xHi), "+r" (xLo), "=&r" (tmp)
-                        : "r" (nComp), "r" (n) );
-  return( (short)xLo );
-}
-
 __attribute__((__always_inline__)) static __inline Word64 SAR64(Word64 x, int n)
 {
   unsigned int xLo = (unsigned int) x;

--- a/src/assembly.h
+++ b/src/assembly.h
@@ -156,18 +156,46 @@ static __inline Word64 SHL64(Word64 x, int n)
 	}
 }
 
-// Shift right 26 and return the lower 16-bits (short)
-static __inline short SAR64_Clip(Word64 x)
+static __inline short SAR64_Clip(Word64 x, int n)
 {
     unsigned int xLo = ((unsigned int *)&x)[0];
     int xHi = ((int *)&x)[1];
+    unsigned char nb = (unsigned char)n;
 
+    if (n < 32) {
         __asm {
             mov        edx, xHi
             mov        eax, xLo
-            mov        cl, 26
+            mov        cl, nb
             shrd    eax, edx, cl
+            sar        edx, cl
         }
+    } else if (n < 64) {
+        /* sar masks cl to 0x1f */
+        __asm {
+            mov        edx, xHi
+            mov        eax, xHi
+            mov        cl, nb
+            sar        edx, 31
+            sar        eax, cl
+        }
+    } else {
+        __asm {
+            sar        xHi, 31
+        }
+        return (short)xHi;
+    }
+// clip
+    __asm {
+        mov xHi,eax
+        mov edx,eax
+        sar xHi, 31     // sign
+        sar edx, 15
+        cmp edx, xHi
+        beq done
+        xor eax,32767
+    done:
+    }
 }
 
 static __inline Word64 SAR64(Word64 x, int n)

--- a/src/assembly.h
+++ b/src/assembly.h
@@ -156,48 +156,6 @@ static __inline Word64 SHL64(Word64 x, int n)
 	}
 }
 
-static __inline short SAR64_Clip(Word64 x, int n)
-{
-    unsigned int xLo = ((unsigned int *)&x)[0];
-    int xHi = ((int *)&x)[1];
-    unsigned char nb = (unsigned char)n;
-
-    if (n < 32) {
-        __asm {
-            mov        edx, xHi
-            mov        eax, xLo
-            mov        cl, nb
-            shrd    eax, edx, cl
-            sar        edx, cl
-        }
-    } else if (n < 64) {
-        /* sar masks cl to 0x1f */
-        __asm {
-            mov        edx, xHi
-            mov        eax, xHi
-            mov        cl, nb
-            sar        edx, 31
-            sar        eax, cl
-        }
-    } else {
-        __asm {
-            sar        xHi, 31
-        }
-        return (short)xHi;
-    }
-// clip
-    __asm {
-        mov xHi,eax
-        mov edx,eax
-        sar xHi, 31     // sign
-        sar edx, 15
-        cmp edx, xHi
-        beq done
-        xor eax,32767
-    done:
-    }
-}
-
 static __inline Word64 SAR64(Word64 x, int n)
 {
 	unsigned int xLo = ((unsigned int *)&x)[0];

--- a/src/polyphase.c
+++ b/src/polyphase.c
@@ -143,7 +143,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase)
 	MC0M(7)
 
 //	*(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 0) = SAR64_Clip(sum1L);
+	*(pcm + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
 
 	/* special case, output sample 16 */
 	coef = coefBase + 256;
@@ -160,7 +160,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase)
 	MC1M(7)
 
 //	*(pcm + 16) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 16) = SAR64_Clip(sum1L);
+	*(pcm + 16) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
 
 	/* main convolution loop: sum1L = samples 1, 2, 3, ... 15   sum2L = samples 31, 30, ... 17 */
 	coef = coefBase + 16;
@@ -183,8 +183,8 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase)
 		vb1 += 64;
 //		*(pcm)       = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
 //		*(pcm + 2*i) = ClipToShort((int)SAR64(sum2L, (32-CSHIFT)), DEF_NFRACBITS);
-		*(pcm) = SAR64_Clip(sum1L);
-		*(pcm + 2*i) = SAR64_Clip(sum2L);
+		*(pcm) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
+		*(pcm + 2*i) = SAR64_Clip(sum2L, (32+DEF_NFRACBITS-CSHIFT));
 		pcm++;
 	}
 }
@@ -261,8 +261,8 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase)
 
 //	*(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
 //	*(pcm + 1) = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 0) = SAR64_Clip(sum1L);
-	*(pcm + 1) = SAR64_Clip(sum1R);
+	*(pcm + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
+	*(pcm + 1) = SAR64_Clip(sum1R, (32+DEF_NFRACBITS-CSHIFT));
 
 	/* special case, output sample 16 */
 	coef = coefBase + 256;
@@ -280,8 +280,8 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase)
 
 //	*(pcm + 2*16 + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
 //	*(pcm + 2*16 + 1) = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 2*16 + 0) = SAR64_Clip(sum1L);
-	*(pcm + 2*16 + 1) = SAR64_Clip(sum1R);
+	*(pcm + 2*16 + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
+	*(pcm + 2*16 + 1) = SAR64_Clip(sum1R, (32+DEF_NFRACBITS-CSHIFT));
 
 	/* main convolution loop: sum1L = samples 1, 2, 3, ... 15   sum2L = samples 31, 30, ... 17 */
 	coef = coefBase + 16;
@@ -305,12 +305,12 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase)
 		vb1 += 64;
 //		*(pcm + 0)         = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
 //		*(pcm + 1)         = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
-		*(pcm + 0) = SAR64_Clip(sum1L);
-		*(pcm + 1) = SAR64_Clip(sum1R);
+		*(pcm + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
+		*(pcm + 1) = SAR64_Clip(sum1R, (32+DEF_NFRACBITS-CSHIFT));
 //		*(pcm + 2*2*i + 0) = ClipToShort((int)SAR64(sum2L, (32-CSHIFT)), DEF_NFRACBITS);
 //		*(pcm + 2*2*i + 1) = ClipToShort((int)SAR64(sum2R, (32-CSHIFT)), DEF_NFRACBITS);
-		*(pcm + 2*2*i + 0) = SAR64_Clip(sum2L);
-		*(pcm + 2*2*i + 1) = SAR64_Clip(sum2R);
+		*(pcm + 2*2*i + 0) = SAR64_Clip(sum2L, (32+DEF_NFRACBITS-CSHIFT));
+		*(pcm + 2*2*i + 1) = SAR64_Clip(sum2R, (32+DEF_NFRACBITS-CSHIFT));
 
 		pcm += 2;
 	}

--- a/src/polyphase.c
+++ b/src/polyphase.c
@@ -142,8 +142,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase)
 	MC0M(6)
 	MC0M(7)
 
-//	*(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
+	*(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
 
 	/* special case, output sample 16 */
 	coef = coefBase + 256;
@@ -159,8 +158,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase)
 	MC1M(6)
 	MC1M(7)
 
-//	*(pcm + 16) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 16) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
+	*(pcm + 16) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
 
 	/* main convolution loop: sum1L = samples 1, 2, 3, ... 15   sum2L = samples 31, 30, ... 17 */
 	coef = coefBase + 16;
@@ -181,10 +179,8 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase)
 		MC2M(7)
 
 		vb1 += 64;
-//		*(pcm)       = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-//		*(pcm + 2*i) = ClipToShort((int)SAR64(sum2L, (32-CSHIFT)), DEF_NFRACBITS);
-		*(pcm) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
-		*(pcm + 2*i) = SAR64_Clip(sum2L, (32+DEF_NFRACBITS-CSHIFT));
+		*(pcm)       = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
+		*(pcm + 2*i) = ClipToShort((int)SAR64(sum2L, (32-CSHIFT)), DEF_NFRACBITS);
 		pcm++;
 	}
 }
@@ -259,10 +255,8 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase)
 	MC0S(6)
 	MC0S(7)
 
-//	*(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-//	*(pcm + 1) = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
-	*(pcm + 1) = SAR64_Clip(sum1R, (32+DEF_NFRACBITS-CSHIFT));
+	*(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
+	*(pcm + 1) = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
 
 	/* special case, output sample 16 */
 	coef = coefBase + 256;
@@ -278,10 +272,8 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase)
 	MC1S(6)
 	MC1S(7)
 
-//	*(pcm + 2*16 + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-//	*(pcm + 2*16 + 1) = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
-	*(pcm + 2*16 + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
-	*(pcm + 2*16 + 1) = SAR64_Clip(sum1R, (32+DEF_NFRACBITS-CSHIFT));
+	*(pcm + 2*16 + 0) = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
+	*(pcm + 2*16 + 1) = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
 
 	/* main convolution loop: sum1L = samples 1, 2, 3, ... 15   sum2L = samples 31, 30, ... 17 */
 	coef = coefBase + 16;
@@ -303,15 +295,10 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase)
 		MC2S(7)
 
 		vb1 += 64;
-//		*(pcm + 0)         = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
-//		*(pcm + 1)         = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
-		*(pcm + 0) = SAR64_Clip(sum1L, (32+DEF_NFRACBITS-CSHIFT));
-		*(pcm + 1) = SAR64_Clip(sum1R, (32+DEF_NFRACBITS-CSHIFT));
-//		*(pcm + 2*2*i + 0) = ClipToShort((int)SAR64(sum2L, (32-CSHIFT)), DEF_NFRACBITS);
-//		*(pcm + 2*2*i + 1) = ClipToShort((int)SAR64(sum2R, (32-CSHIFT)), DEF_NFRACBITS);
-		*(pcm + 2*2*i + 0) = SAR64_Clip(sum2L, (32+DEF_NFRACBITS-CSHIFT));
-		*(pcm + 2*2*i + 1) = SAR64_Clip(sum2R, (32+DEF_NFRACBITS-CSHIFT));
-
+		*(pcm + 0)         = ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);
+		*(pcm + 1)         = ClipToShort((int)SAR64(sum1R, (32-CSHIFT)), DEF_NFRACBITS);
+		*(pcm + 2*2*i + 0) = ClipToShort((int)SAR64(sum2L, (32-CSHIFT)), DEF_NFRACBITS);
+		*(pcm + 2*2*i + 1) = ClipToShort((int)SAR64(sum2R, (32-CSHIFT)), DEF_NFRACBITS);
 		pcm += 2;
 	}
 }


### PR DESCRIPTION
In #9 an optimization of the recurring code snippet `ClipToShort((int)SAR64(sum1L, (32-CSHIFT)), DEF_NFRACBITS);` was implemented.  However, the new function `SAR64_Clip` didn't actually function the same as the original, because they differ in how out-of-range values are treated: SAR64_Clip actually just masks off the high bits, while ClipToShort clips out of bound values to the minimum and maximum.

This closes #12.

Testing performed: ran the standalone test and did _NOT_ see any reports of "likely overflows".  Listened to the "Carpeter" track in a custom build of CircuitPython with this version of the mp3 library and it sounded right too.