### PR TITLE
Only enable ARM intrinsics on ARM7 (Cortex M4) and better.

### DIFF
--- a/src/assembly.h
+++ b/src/assembly.h
@@ -271,7 +271,7 @@ static __inline int CLZ(int x)
 	return numZeros;
 }
 
-#elif defined(__GNUC__) && (defined(ARM) || defined(__ARMEL__))
+#elif defined(__GNUC__) && (defined(ARM) || defined(__ARMEL__)) && (__ARM_ARCH >= 7)
 
 static __inline int MULSHIFT32(int x, int y)
 {
@@ -510,8 +510,6 @@ __attribute__((__always_inline__)) static __inline Word64 SAR64(Word64 x, int n)
 #else
 
 #include <stdint.h>
-
-#warning "Using generic implementation of intrinsics"
 
 typedef int64_t Word64;
 

--- a/src/mp3dec.h
+++ b/src/mp3dec.h
@@ -74,6 +74,8 @@
 #
 #elif defined(__MK66FX1M0__) || defined(__MK64FX512__) || defined(__MK20DX256__)	/* teensy 3.6, 3.5, or 3.1/2 */
 #
+#elif defined(MP3DEC_GENERIC)
+#
 #else
 #error No platform defined. See valid options in mp3dec.h
 #endif


### PR DESCRIPTION
This makes ARM6 (M0+) get the generic implementation.  It's not pretty, but it does compile.  The Raspberry Pi Pico is actually able to play (some) 32kbit/s streams in this case.